### PR TITLE
use npm as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ In this scenario, you will still be prompted to input values for your preferred 
 
 ### Selecting a package manager
 
+If no package manager is specified, the default package manager will be `npm`.
+
 If you wanted to use [`yarn`](https://yarnpkg.com/) to install the packages automatically:
 
 ```sh

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -35,7 +35,7 @@ export default class Cli {
   extractManualIntallInstructions(install: boolean | "npm" | "yarn" | "pnpm") {
     if (typeof install !== "string") {
       this.args.install = install;
-      this.args.pkgMgr = "";
+      this.args.pkgMgr = "npm"; // default package manager is npm
     } else {
       this.args.pkgMgr = install;
       this.args.install = true;


### PR DESCRIPTION
Sets the default package manager to be `npm`.

Updated `readme.md` as well.