### PR TITLE
Remove mentions of Optimize and Accelerate

### DIFF
--- a/src/cli/prompts.ts
+++ b/src/cli/prompts.ts
@@ -55,11 +55,6 @@ const selectORMorPDP = async () => {
         value: "accelerate",
         description: "Perform caching and connection pooling",
       },
-      {
-        name: `Prisma Optimize`,
-        value: "optimize",
-        description: "Analyze and improve query performance",
-      },
     ],
   });
 };

--- a/src/cli/prompts.ts
+++ b/src/cli/prompts.ts
@@ -12,7 +12,7 @@ const selectStarterOrExample = async (): Promise<string> => {
         name: `Prisma Starter (Recommended)`,
         value: "starter",
         description:
-          "The Prisma Starter is pre-configured with Prisma ORM, Accelerate, and a Prisma Postgres database.",
+          "The Prisma Starter is pre-configured with Prisma ORM and a Prisma Postgres database.",
       },
       {
         name: "Explore other examples",
@@ -49,11 +49,6 @@ const selectORMorPDP = async () => {
         name: `Prisma ORM`,
         value: "orm",
         description: "Define Prisma schema and run queries",
-      },
-      {
-        name: `Prisma Accelerate`,
-        value: "accelerate",
-        description: "Perform caching and connection pooling",
       },
     ],
   });

--- a/src/cli/validation.ts
+++ b/src/cli/validation.ts
@@ -35,7 +35,7 @@ export default {
   rootDir(path: string) {
     if (!EXAMPLES_DIR_ACCEPT.includes(path)) {
       throw new Error(
-        "Invalid template. Please choose a template from the `typescript`, `databases`, or `accelerate` directories in the prisma/prisma-examples repository.",
+        "Invalid template. Please choose a template from the `typescript` or `databases` directories in the prisma/prisma-examples repository.",
       );
     }
   },

--- a/src/cli/validation.ts
+++ b/src/cli/validation.ts
@@ -35,7 +35,7 @@ export default {
   rootDir(path: string) {
     if (!EXAMPLES_DIR_ACCEPT.includes(path)) {
       throw new Error(
-        "Invalid template. Please choose a template from the `typescript`, `databases`, `accelerate`, or `optimize` directories in the prisma/prisma-examples repository.",
+        "Invalid template. Please choose a template from the `typescript`, `databases`, or `accelerate` directories in the prisma/prisma-examples repository.",
       );
     }
   },

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,9 +7,4 @@ export const EXAMPLES_REPO_TAR =
 export const EXAMPLES_REPO_INTERCEPTOR =
   "https://www.try-prisma-analytics.com/api/interceptor";
 
-export const EXAMPLES_DIR_ACCEPT = [
-  "typescript",
-  "databases",
-  "orm",
-  "accelerate",
-];
+export const EXAMPLES_DIR_ACCEPT = ["typescript", "databases", "orm"];

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,5 +12,4 @@ export const EXAMPLES_DIR_ACCEPT = [
   "databases",
   "orm",
   "accelerate",
-  "optimize",
 ];

--- a/src/helpers/getProjects.ts
+++ b/src/helpers/getProjects.ts
@@ -41,12 +41,7 @@ export default async function getProjects() {
   const paths = Object.keys(mergedData).map((item) => {
     const folders = item.split("/");
     if (folders.length >= 3) {
-      if (item.includes("optimize")) {
-        projectsWithSubfolders.push(folders[1]);
-        return folders.slice(0, 2).join("/");
-      } else {
-        projectsWithSubfolders.push(folders[1]);
-      }
+      projectsWithSubfolders.push(folders[1]);
     }
 
     return folders.length >= 3 ? folders.slice(0, -1).join("/") : item;

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,10 +26,6 @@ const main = async () => {
     if (!isProjectWithSubdirectory) {
       await installPackages(input.pkgMgr, `${input.path}/${input.name}`);
     } else {
-      if (cli.args.template.includes("optimize/starter")) {
-        await installPackages(input.pkgMgr, `${input.path}/${input.name}`);
-      }
-
       if (cli.args.template.includes("rest-nextjs-express")) {
         await installPackages(
           input.pkgMgr,

--- a/test/helpers/getProjects.test.ts
+++ b/test/helpers/getProjects.test.ts
@@ -96,19 +96,19 @@ describe("Get Projects", () => {
       json: () => ({
         tree: [
           {
-            path: "accelerate",
-            type: "tree",
-          },
-          {
-            path: "accelerate/package.json",
-            type: "blob",
-          },
-          {
             path: "orm",
             type: "tree",
           },
           {
             path: "orm/package.json",
+            type: "blob",
+          },
+          {
+            path: "databases",
+            type: "tree",
+          },
+          {
+            path: "databases/package.json",
             type: "blob",
           },
         ],
@@ -118,7 +118,7 @@ describe("Get Projects", () => {
     console.log(data[0]);
     expect(data[0].length).toBe(2);
     expect(data[0]).toContain("orm");
-    expect(data[0]).toContain("accelerate");
+    expect(data[0]).toContain("databases");
   });
 
   it("Should return valid projects and filter bad projects", async () => {


### PR DESCRIPTION
## Summary
- Removed `"optimize"` and `"accelerate"` from the `EXAMPLES_DIR_ACCEPT` list in constants
- Removed the Prisma Optimize and Prisma Accelerate choices from the CLI selection prompt
- Removed Accelerate mention from the Prisma Starter description
- Removed optimize-specific install and subfolder handling logic
- Updated validation error message to no longer reference `optimize` or `accelerate`
- Updated tests to reflect the changes

## Test plan
- [x] All existing tests pass (22/22)
- [x] Lint and format checks pass